### PR TITLE
Add email provider

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -67,6 +67,12 @@ func (c *Client) init() error {
 		return errors.New("missing 'path")
 	}
 
+	var email provider.Email
+	if err := email.Init(); err != nil {
+		return fmt.Errorf("fail to iniitalize the email provider: %w", err)
+	}
+	c.providers = append(c.providers, email)
+
 	for _, github := range c.Provider.Github {
 		client := provider.GitHub{
 			Token:      github.Token,

--- a/internal/service/provider/email.go
+++ b/internal/service/provider/email.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"regexp"
+)
+
+type emailChecker interface {
+	exists(domain string) (bool, error)
+}
+
+// Email handles the verification of email addresses.
+type Email struct {
+	checker emailChecker
+	regex   regexp.Regexp
+}
+
+// Init internal state.
+func (e *Email) Init() error {
+	if err := e.initRegex(); err != nil {
+		return fmt.Errorf("fail to initialize the regex: %w", err)
+	}
+
+	if e.checker == nil {
+		e.checker = emailNetLookupMX{}
+	}
+
+	return nil
+}
+
+// Authority checks if the email provider is responsible to process the entry.
+func (e Email) Authority(uri string) bool {
+	return e.regex.Match([]byte(uri))
+}
+
+// Valid check if the address is valid.
+func (e Email) Valid(ctx context.Context, _, uri string) (bool, error) {
+	fragments := e.regex.FindStringSubmatch(uri)
+	if fragments == nil {
+		return false, nil
+	}
+
+	exists, err := e.checker.exists(fragments[1])
+	if err != nil {
+		return false, fmt.Errorf("fail to check the MX DNS entries: %w", err)
+	}
+	return exists, nil
+}
+
+func (e *Email) initRegex() error {
+	rawExpr := "^mailto:[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@(?P<domain>[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*)"
+	expr, err := regexp.Compile(rawExpr)
+	if err != nil {
+		return fmt.Errorf("fail to compile the expression '%s': %w", rawExpr, err)
+	}
+	e.regex = *expr
+	return nil
+}
+
+type emailNetLookupMX struct{}
+
+func (emailNetLookupMX) exists(domain string) (bool, error) {
+	mxs, err := net.LookupMX(domain)
+	if err != nil {
+		return false, err
+	}
+	return (len(mxs) > 0), nil
+}

--- a/internal/service/provider/email_test.go
+++ b/internal/service/provider/email_test.go
@@ -1,0 +1,151 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmailInit(t *testing.T) {
+	t.Parallel()
+	var client Email
+	require.NoError(t, client.Init())
+}
+
+func TestEmailAuthority(t *testing.T) {
+	t.Parallel()
+
+	var client Email
+	require.NoError(t, client.Init())
+
+	tests := []struct {
+		message      string
+		uri          string
+		hasAuthority bool
+	}{
+		{
+			message:      "have authority #1",
+			uri:          "mailto:milo@gonitro.com",
+			hasAuthority: true,
+		},
+		{
+			message:      "have authority #2",
+			uri:          "mailto:milo@gonitro.com?subject=something",
+			hasAuthority: true,
+		},
+		{
+			message:      "have no authority #1",
+			uri:          "http://something.com",
+			hasAuthority: false,
+		},
+		{
+			message:      "have no authority #2",
+			uri:          "milo@gonitro.com",
+			hasAuthority: false,
+		},
+		{
+			message:      "have no authority #2",
+			uri:          "milo@gonitro.com?subject=something",
+			hasAuthority: false,
+		},
+	}
+
+	for i := 0; i < len(tests); i++ {
+		tt := tests[i]
+		t.Run("Should "+tt.message, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.hasAuthority, client.Authority(tt.uri))
+		})
+	}
+}
+
+func TestEmailValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		message   string
+		ctx       context.Context
+		checker   emailChecker
+		uri       string
+		isValid   bool
+		shouldErr bool
+	}{
+		{
+			message:   "attest the email as valid",
+			ctx:       context.Background(),
+			checker:   emailCheckerMock{response: true, shouldErr: false},
+			uri:       "mailto:milo@gonitro.com",
+			shouldErr: false,
+			isValid:   true,
+		},
+		{
+			message:   "attest the email with name as valid",
+			ctx:       context.Background(),
+			checker:   emailCheckerMock{response: true, shouldErr: false},
+			uri:       "mailto:milo@gonitro.com?subject=something",
+			shouldErr: false,
+			isValid:   true,
+		},
+		{
+			message:   "attest the email as invalid #1",
+			ctx:       context.Background(),
+			checker:   emailCheckerMock{response: true, shouldErr: false},
+			uri:       "something",
+			shouldErr: false,
+			isValid:   false,
+		},
+		{
+			message:   "attest the email as invalid #2",
+			ctx:       context.Background(),
+			checker:   emailCheckerMock{response: true, shouldErr: false},
+			uri:       "http://gonitro.com",
+			shouldErr: false,
+			isValid:   false,
+		},
+		{
+			message:   "attest the email as invalid #3",
+			ctx:       context.Background(),
+			checker:   emailCheckerMock{response: false, shouldErr: false},
+			uri:       "unknow@email.com",
+			shouldErr: false,
+			isValid:   false,
+		},
+		{
+			message:   "attest the email as invalid #4",
+			ctx:       context.Background(),
+			checker:   emailCheckerMock{response: false, shouldErr: true},
+			uri:       "mailto:valid@email.com",
+			shouldErr: true,
+			isValid:   false,
+		},
+	}
+
+	for i := 0; i < len(tests); i++ {
+		tt := tests[i]
+		t.Run("Should "+tt.message, func(t *testing.T) {
+			client := Email{checker: tt.checker}
+			require.NoError(t, client.Init())
+
+			isValid, err := client.Valid(tt.ctx, "", tt.uri)
+			require.Equal(t, tt.shouldErr, (err != nil))
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.isValid, isValid)
+		})
+	}
+}
+
+type emailCheckerMock struct {
+	response  bool
+	shouldErr bool
+}
+
+func (e emailCheckerMock) exists(domain string) (bool, error) {
+	if e.shouldErr {
+		return false, errors.New("error during the email check")
+	}
+	return e.response, nil
+}


### PR DESCRIPTION
This provider verifies links like this `mailto:something@mail.com`. This is not perfect validation as the email may not exist but we check if the domain has configured mx entries at the DNS.