### PR TITLE
Fix the output of the relative path

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -180,7 +180,7 @@ func (Client) hasInvalidLink(entries []service.Entry) bool {
 }
 
 func (c Client) relativePath(path string) string {
-	return strings.Replace(path, c.Path, "", -1)
+	return strings.TrimPrefix(path, c.Path)
 }
 
 type serviceEntrySort []service.Entry


### PR DESCRIPTION
The previous code had a bug when the current path is declared as '.' as it did remove all the dots from the path like 'file.md' being transformed in 'filemd'.